### PR TITLE
[MRG] Motif Clustering

### DIFF
--- a/ndspflow/core/motif.py
+++ b/ndspflow/core/motif.py
@@ -4,12 +4,15 @@ import numpy as np
 from scipy.signal import resample
 import pandas as pd
 
+from sklearn.cluster import KMeans
+from sklearn.metrics import silhouette_score
+
 from neurodsp.utils.norm import normalize_sig
 from ndspflow.core.utils import limit_df
 
 
-def extract_motifs(fm, df_features, sig, fs, scaling=1, normalize=True,
-                   weights=None, only_bursts=True, center='peak'):
+def extract_motifs(fm, df_features, sig, fs, scaling=1, only_bursts=True,
+                   center='peak', thresh=1, max_clusters=10, return_cycles=False):
     """Get the average cycle from a bycycle dataframe for all fooof peaks.
 
     Parameters
@@ -22,22 +25,26 @@ def extract_motifs(fm, df_features, sig, fs, scaling=1, normalize=True,
         Time series.
     scaling : float, optional, default: 1
         The scaling of the bandwidth from the center frequencies to limit cycles to.
-    normalize : bool, optional, default: True
-        Normalizes each cycle (mean centers with variance of one) when True.
-    weights : 1d array, optional, default: None
-        Used for weighting cycles (i.e. a function of distance from the center frequency), when
-        averaging cycle waveforms.
     only_burst : bool, optional, default: True
         Limits the dataframe to bursting cycles when True.
     center : {'peak', 'trough'}, optional
         The center definition of cycles.
+    thresh : float, optional, default: 1
+        The silhouette score for accepting putative k clusters.
+    max_clusters : int, optional, default: 10
+        The maximum number of clusters to evaluate.
+    return_cycles : bool, optiona, default: False
+        Returns the signal, dataframe, and label for each cycle.
 
     Returns
     -------
-    motifs : list of 1d arrays
-        Motifs for each center frequency in ascending order.
-    dfs_osc : list of pd.DataFrame
-        The subsetted dataframe used to find each motif.
+    motifs : list of list of 1d arrays
+        Motifs for each center frequency in ascending order. Inner list contains multiple arrays
+        if multiple motifs are found at one frequency.
+    cycles : dict
+        The timeseries, dataframes, frequency ranges, and predicted labels for each cycle.
+        Valid keys include: 'sigs', 'dfs_osc', 'labels', 'f_ranges'.
+        Only returned when ``return_cycles`` is True.
     """
 
     # Extract center freqs and bandwidths from fooof fit
@@ -51,27 +58,50 @@ def extract_motifs(fm, df_features, sig, fs, scaling=1, normalize=True,
 
     # Get cycles within freq ranges
     motifs = []
-    dfs_osc = []
+    cycles = {'sigs': [], 'dfs_osc': [], 'labels': [], 'f_ranges': []}
 
     for f_range in f_ranges:
 
         # Restrict dataframe to frequency range
         df_osc = limit_df(df_features, fs, f_range, only_bursts=only_bursts)
-        dfs_osc.append(df_osc)
 
-        # No cycles left after limiting
+        # No cycles found in frequency range
         if not isinstance(df_osc, pd.DataFrame):
             motifs.append(np.nan)
+            for key in cycles:
+                cycles[key].append(np.nan)
             continue
 
-        motif = extract_motif(df_osc, sig, normalize, weights, center)
-        motifs.append(motif)
+        # Split signal into 2d array of cycles
+        sig_cyc = split_signal(df_osc, sig, True, center)
 
-    return motifs, dfs_osc
+        # Cluster cycles
+        labels = cluster_motifs(sig_cyc, thresh=thresh, max_clusters=max_clusters)
+
+        # Collect cycles if requested
+        cycles['sigs'].append(sig_cyc)
+        cycles['dfs_osc'].append(df_osc)
+        cycles['labels'].append(labels)
+        cycles['f_ranges'].append(f_range)
+
+        if not isinstance(labels, np.ndarray):
+            # No superthreshold clusters found
+            motifs.append([np.mean(sig_cyc, axis=0)])
+        else:
+            # Multiple motifs found at the current frequency range
+            multi_motifs = []
+            for idx in range(max(labels)+1):
+                multi_motifs.append(np.mean(sig_cyc[np.where(labels == idx)[0]], axis=0))
+            motifs.append(multi_motifs)
+
+    if return_cycles:
+        return motifs, cycles
+
+    return motifs
 
 
-def extract_motif(df_osc, sig, normalize=True, weights=None, center='peak'):
-    """Get the average cycle from a bycycle dataframe.
+def split_signal(df_osc, sig, normalize=True, center='peak'):
+    """Split the signal from a bycycle dataframe.
 
     Parameters
     ----------
@@ -82,23 +112,13 @@ def extract_motif(df_osc, sig, normalize=True, weights=None, center='peak'):
         Time series.
     normalize : bool, optional, default: True
         Normalizes each cycle (mean centers with variance of one) when True.
-    weights : 1d array, optional, default: None
-        Used for weighting cycles (i.e. a function of distance from the center frequency), when
-        averaging cycle waveforms.
     center : {'peak', 'trough'}, optional
         The center definition of cycles.
 
     Returns
     -------
-    sig_motif : 1d array
-        The averaged waveform.
-
-    Notes
-    -----
-
-    - The returned motif will contain a number of samples equal to the mean in the dataframe.
-    - When no cycles are found within the frequency range, np.nan is returned.
-
+    sigs : 2d array
+        Each cycle resampled to the mean of the dataframe.
     """
 
     # Get the start/end samples of each cycle
@@ -111,7 +131,7 @@ def extract_motif(df_osc, sig, normalize=True, weights=None, center='peak'):
 
     n_samples = np.mean(samples, dtype=int)
 
-    sig_motif = np.zeros((len(cyc_start), n_samples))
+    sigs = np.zeros((len(cyc_start), n_samples))
 
     # Slice cycles and resample to center frequency
     for idx, (start, end) in enumerate(zip(cyc_start, cyc_end)):
@@ -122,9 +142,50 @@ def extract_motif(df_osc, sig, normalize=True, weights=None, center='peak'):
         if normalize:
             sig_cyc = normalize_sig(sig_cyc, mean=0, variance=1)
 
-        sig_motif[idx] = sig_cyc
+        sigs[idx] = sig_cyc
 
-    # Take the weigthed average of the cycles
-    sig_motif = np.average(sig_motif, axis=0, weights=weights)
+    return sigs
 
-    return sig_motif
+
+def cluster_motifs(motifs, thresh=0.5, max_clusters=10):
+    """K-means clustering of motifs.
+
+    Parameters
+    ----------
+    motifs : 2D array
+        Cycles within a frequency range.
+    thresh : float, optional, default: 0.5
+        The silhouette score for accepting putative k clusters.
+    max_cluster : int, optional, default: 10
+        The maximum number of clusters to evaluate.
+
+    Returns
+    -------
+    labels : 1d array
+        The predicted cluster each motif belongs to.
+    """
+
+    # Nothing to cluster
+    if len(motifs) == 1:
+        return np.nan
+
+    max_clusters = len(motifs) if len(motifs) < max_clusters else max_clusters
+
+    labels = []
+    scores = []
+    for n_clusters in range(2, max_clusters+1):
+
+        clusters = KMeans(n_clusters=n_clusters, algorithm="full").fit_predict(motifs)
+
+        labels.append(clusters)
+
+        scores.append(silhouette_score(motifs, clusters))
+
+    # No superthreshold clusters found
+    if max(scores) < thresh:
+        return np.nan
+
+    # Split motifs based on highest silhouette score
+    labels = labels[np.argmax(scores)]
+
+    return labels

--- a/ndspflow/core/motif.py
+++ b/ndspflow/core/motif.py
@@ -23,6 +23,8 @@ def extract_motifs(fm, df_features, sig, fs, scaling=1, only_bursts=True,
         A dataframe containing bycycle features.
     sig : 1d array
         Time series.
+    fs : float
+        Sampling rate, in Hz.
     scaling : float, optional, default: 1
         The scaling of the bandwidth from the center frequencies to limit cycles to.
     only_burst : bool, optional, default: True
@@ -127,11 +129,9 @@ def split_signal(df_osc, sig, normalize=True, center='peak'):
     cyc_end = df_osc['sample_next_' + side].values
 
     # Get the average number of samples
-    samples = np.array([end-start for start, end in zip(cyc_start, cyc_end)])
+    n_samples = np.mean(df_osc['period'].values, dtype=int)
 
-    n_samples = np.mean(samples, dtype=int)
-
-    sigs = np.zeros((len(cyc_start), n_samples))
+    sigs = np.zeros((len(df_osc), n_samples))
 
     # Slice cycles and resample to center frequency
     for idx, (start, end) in enumerate(zip(cyc_start, cyc_end)):

--- a/ndspflow/plts/motif.py
+++ b/ndspflow/plts/motif.py
@@ -46,12 +46,18 @@ def plot_motifs(fm, df_features, sig, fs, n_bursts=5, center='peak',
     # Extract motifs
     sig = normalize_sig(sig, mean=0, variance=1) if normalize else sig
     extract_motifs_kwargs = {} if extract_motifs_kwargs is None else extract_motifs_kwargs
-    motifs, dfs_osc = extract_motifs(fm, df_features, sig, fs, **extract_motifs_kwargs)
-    motif_exists = [isinstance(motif, np.ndarray) for motif in motifs]
+    motifs, cycles = extract_motifs(fm, df_features, sig, fs, return_cycles=True,
+                                    **extract_motifs_kwargs)
+
+    # Get indices where motifs are found with greater than 1 cycle
+    dfs_osc = cycles['dfs_osc']
+    motif_exists = ~np.array([isinstance(motif, float) for motif in motifs])
+    drop = [idx for idx in np.where(motif_exists)[0] if len(dfs_osc[idx]) <= 1]
+    motif_exists[drop] = False
 
     # Initialize figure
     ncols = len(motifs)
-    nrows = 2 + len(np.nonzero(motif_exists)[0])
+    nrows = len(np.nonzero(motif_exists)[0]) + 2
 
     specs = [
         [{'colspan': ncols, 'b': .4/nrows}, *[None] * (ncols-1)],
@@ -95,33 +101,38 @@ def plot_motifs(fm, df_features, sig, fs, n_bursts=5, center='peak',
     # Plot motifs and example bursting segments
     times = np.arange(0, len(sig)/fs, 1/fs)
 
-    motif_idxs = [idx for idx, motif in enumerate(motifs) if isinstance(motif, (np.ndarray, list))]
+    motif_idxs = np.where(motif_exists)[0]
     last_motif_idx = motif_idxs[-1] if len(motif_idxs) > 0 else None
 
-    sig_idx = 1
+    # Iterate over each center freq
+    row_idx = 1
     for idx, (motif, df_osc) in enumerate(zip(motifs, dfs_osc)):
 
         color = default_fills[idx % len(default_fills)]
 
         if idx in motif_idxs:
 
-            # Plot motifs
-            fig.add_trace(go.Scatter(x=times, y=motif, line={'color': color}, mode='lines',
-                                     showlegend=False, hoverinfo='none'),
-                          row=2, col=idx+1)
+            # Iterate over motif(s) at each center freq
+            for sub_motif in motif:
 
-            # Plot example bursting segments
-            (start, end) = _find_short_burst(df_osc, n_bursts, center)
+                # Plot motifs
+                fig.add_trace(go.Scatter(x=times, y=sub_motif, line={'color': color}, mode='lines',
+                                        showlegend=False, hoverinfo='none'),
+                            row=2, col=idx+1)
 
-            fig.add_trace(go.Scatter(x=times[start:end], y=sig[start:end],
-                                     line={'color': color}, showlegend=False),
-                          row=2+sig_idx, col=1, )
+                # Plot example bursting segments
+                (start, end) = _find_short_burst(df_osc, n_bursts, center)
 
-            if idx == last_motif_idx:
-                fig.update_xaxes(title_text='Time (s)', row=2+sig_idx, col=1)
+                fig.add_trace(go.Scatter(x=times[start:end], y=sig[start:end],
+                                        line={'color': color}, showlegend=False),
+                            row=2+row_idx, col=1)
 
-            fig.update_yaxes(title_text='Normalized Voltage', row=2+sig_idx, col=1)
-            sig_idx += 1
+                if idx == last_motif_idx:
+                    fig.update_xaxes(title_text='Time (s)', row=2+row_idx, col=1)
+
+                fig.update_yaxes(title_text='Normalized Voltage', row=2+row_idx, col=1)
+
+            row_idx += 1
 
         else:
 
@@ -132,7 +143,7 @@ def plot_motifs(fm, df_features, sig, fs, n_bursts=5, center='peak',
                     text=["No<br>Oscillation<br>Found"],
                     textposition="middle center",
                     textfont=dict(
-                        size=24,
+                        size=18,
                         color=color.replace('.5', '.75')
                     ),
                     showlegend=False,

--- a/ndspflow/plts/motif.py
+++ b/ndspflow/plts/motif.py
@@ -12,13 +12,13 @@ from ndspflow.plts.fooof import plot_fm
 from ndspflow.core.motif import extract_motifs
 
 
-def plot_motifs(fm, df_features, sig, fs, n_bursts=5, center='peak',
-                normalize=True, extract_motifs_kwargs=None, plot_fm_kwargs=None):
+def plot_motifs(fm, df_features, sig, fs, n_bursts=5, center='peak', normalize=True,
+                motifs=None, cycles=None, extract_motifs_kwargs=None, plot_fm_kwargs=None):
     """Plot cycle motifs using fooof fits and bycycle cycles.
 
     Parameters
     ----------
-    fm : fooof FOOOF
+    fm : fooof FOOOF or tuple
         A fooof model that has been fit.
     df_features : pandas.DataFrame
         A dataframe containing bycycle features.
@@ -46,8 +46,11 @@ def plot_motifs(fm, df_features, sig, fs, n_bursts=5, center='peak',
     # Extract motifs
     sig = normalize_sig(sig, mean=0, variance=1) if normalize else sig
     extract_motifs_kwargs = {} if extract_motifs_kwargs is None else extract_motifs_kwargs
-    motifs, cycles = extract_motifs(fm, df_features, sig, fs, return_cycles=True,
-                                    **extract_motifs_kwargs)
+
+    if motifs is None or cycles is None:
+
+        motifs, cycles = extract_motifs(fm, df_features, sig, fs, return_cycles=True,
+                                        **extract_motifs_kwargs)
 
     # Get indices where motifs are found with greater than 1 cycle
     dfs_osc = cycles['dfs_osc']
@@ -65,10 +68,10 @@ def plot_motifs(fm, df_features, sig, fs, n_bursts=5, center='peak',
         *[[{'colspan': ncols, 'b': .1/nrows}, *[None] * (ncols-1)]] * (nrows-2)
     ]
 
-    row_heights = [2, 1, *[1] * (nrows-2)]
-
-    titles = fm.get_params('gaussian_params')[:, 0].round(1).astype(str)
+    titles = [str(round(fs/len(motif[0]))) for motif in motifs if not isinstance(motif, float)]
     titles = [osc + ' hz Motif' for osc in titles]
+
+    row_heights = [2, 1, *[1] * (nrows-2)]
 
     fig = make_subplots(
         rows=nrows, cols=ncols, row_heights=row_heights, specs=specs,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ plotly >= 4.10.0
 ipywidgets >= 7.5.1
 pytest >= 6.0.2
 pytest-cov >= 2.10.1
+scikit-learn==0.24.1


### PR DESCRIPTION
This is an extension of #13 that allows different waveform shapes to be untangled at the same frequency. Before multiple waveforms would be average into a single motif. Disentangling motifs is done with k-means clustering with the raw signal (it could also be updated to use the bycycle df). There is a score threshold for accepting k-clusters - by default it is set to 1, to return a single shape. If the threshold is lowered, multiple shapes can be untangled at a single frequency.

Here's an example of a single signal with 1/f + 10hz bursty asine waves with rdsyms of 0.25, 0.50, and 0.75. This isn't a great example since bycycle will give you rdsyms - making it easy to separate without clustering but this may also work with shape features that bycycle doesn't include.

![motif_2](https://user-images.githubusercontent.com/34786005/106980123-77b09480-6714-11eb-8a1a-091ddf69aaad.png)